### PR TITLE
Include explicit headers to unblock cmd line usage of UnrealBuildTool

### DIFF
--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/NuGetModule/Private/NuGetModule.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/NuGetModule/Private/NuGetModule.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Modules/ModuleInterface.h"
+#include "Modules/ModuleManager.h"
 
 class FNuGetModule : public IModuleInterface
 {


### PR DESCRIPTION
Headers needed for IModuleInterface and IMPLEMENT_MODULE