### PR TITLE
Jacksonf/remoting 2 5

### DIFF
--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1",
+	"VersionName": "1.1.1",
 	"FriendlyName": "Microsoft OpenXR",
 	"Description": "The Microsoft OpenXR plugin is a game plugin which provides additional features available on Microsoft's Mixed Reality devices like the HoloLens 2 when using OpenXR.",
 	"Category": "Augmented Reality",

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/AzureSpatialAnchorsForOpenXR.Build.cs
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/AzureSpatialAnchorsForOpenXR.Build.cs
@@ -33,6 +33,7 @@ namespace UnrealBuildTool.Rules
 					"HeadMountedDisplay",
 					"OpenXRHMD",
 					"NuGetModule",
+					"Projects",
 					"MicrosoftOpenXR"
 				}
 			);

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/Private/AzureSpatialAnchorsForOpenXR.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/Private/AzureSpatialAnchorsForOpenXR.cpp
@@ -19,8 +19,8 @@ void FAzureSpatialAnchorsForOpenXR::StartupModule()
 {
 	IModularFeatures::Get().RegisterModularFeature(IAzureSpatialAnchors::GetModularFeatureName(), static_cast<IAzureSpatialAnchors*>(this));
 
-	const FString LibrariesDir = FPaths::ProjectPluginsDir() / "MicrosoftOpenXR" / THIRDPARTY_BINARY_SUBFOLDER;
-	FString PackageRelativePath(LibrariesDir);
+	const FString PluginBaseDir = IPluginManager::Get().FindPlugin("MicrosoftOpenXR")->GetBaseDir();
+	FString PackageRelativePath = PluginBaseDir / THIRDPARTY_BINARY_SUBFOLDER;
 
 	// On HoloLens, DLLs must be loaded relative to the package with no ".."'s in the path. 
 	// If using FPlatformProcess::PushDLLDirectory, the library path must be made relative to the RootDir.

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/Public/AzureSpatialAnchorsForOpenXR.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/Public/AzureSpatialAnchorsForOpenXR.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #if PLATFORM_WINDOWS || PLATFORM_HOLOLENS
+#include "Interfaces/IPluginManager.h"
+
 #include "OpenXRCommon.h"
 
 #include "IAzureSpatialAnchors.h"

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
@@ -31,7 +31,8 @@ namespace MicrosoftOpenXR
 
 		if (remotingEnabled)
 		{
-			const FString RemotingJsonPath = FPaths::ProjectPluginsDir() / "MicrosoftOpenXR" / THIRDPARTY_BINARY_SUBFOLDER / "RemotingXR.json";
+			const FString PluginBaseDir = IPluginManager::Get().FindPlugin("MicrosoftOpenXR")->GetBaseDir();
+			const FString RemotingJsonPath = PluginBaseDir / THIRDPARTY_BINARY_SUBFOLDER / "RemotingXR.json";
 
 			if (FPaths::FileExists(RemotingJsonPath))
 			{

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.h
@@ -8,6 +8,8 @@
 
 #if SUPPORTS_REMOTING
 
+#include "Interfaces/IPluginManager.h"
+
 #include "OpenXRCommon.h"
 #include "openxr_msft_holographic_remoting.h "
 

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.cpp
@@ -23,8 +23,9 @@ namespace MicrosoftOpenXR
 	{
 		IModularFeatures::Get().RegisterModularFeature(IOpenXRExtensionPlugin::GetModularFeatureName(), this);
 #if PLATFORM_WINDOWS
+		const FString PluginBaseDir = IPluginManager::Get().FindPlugin("MicrosoftOpenXR")->GetBaseDir();
 		const FString DllName = "Microsoft.MixedReality.QR.dll";
-		const FString LibrariesDir = FPaths::ProjectPluginsDir() / "MicrosoftOpenXR"/ THIRDPARTY_BINARY_SUBFOLDER;
+		const FString LibrariesDir = PluginBaseDir / THIRDPARTY_BINARY_SUBFOLDER;
 
 		FPlatformProcess::PushDllDirectory(*LibrariesDir);
 		if (!FPlatformProcess::GetDllHandle(*DllName))

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #if PLATFORM_WINDOWS || PLATFORM_HOLOLENS
+#include "Interfaces/IPluginManager.h"
+
 #include "OpenXRCommon.h"
 #include "ARTypes.h"
 

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/NuGetModule/packages.config
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/NuGetModule/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.MixedReality.QR" version="0.5.2103" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.7" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.201217.4" targetFramework="native" />
-  <package id="Microsoft.Holographic.Remoting.OpenXr" version="2.4.0" targetFramework="native" />
+  <package id="Microsoft.Holographic.Remoting.OpenXr" version="2.5.0" targetFramework="native" />
   <package id="Microsoft.Azure.SpatialAnchors.WinRT" version="2.7.0" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Update to latest 2.5 remoting NuGet feed

Update plugin binary lookup to search from the MicrosoftOpenXR plugin directory directly, rather than the game plugin directory. This fixes binary lookup when using the plugin from the Marketplace, where this plugin is an engine plugin.

Update plugin version to 1.1.1