### PR TITLE
Marketplace plugin fixes

### DIFF
--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1.1",
+	"VersionName": "1.1.2",
 	"FriendlyName": "Microsoft OpenXR",
 	"Description": "The Microsoft OpenXR plugin is a game plugin which provides additional features available on Microsoft's Mixed Reality devices like the HoloLens 2 when using OpenXR.",
 	"Category": "Augmented Reality",
@@ -39,7 +39,8 @@
 			"Type": "Runtime",
 			"LoadingPhase": "PostConfigInit",
 			"WhitelistPlatforms": [
-				"Win64"
+				"Win64",
+				"HoloLens"
 			]
 		},
 		{

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Public/MicrosoftOpenXR.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Public/MicrosoftOpenXR.h
@@ -15,10 +15,10 @@ struct FKeywordInput
 {
 	GENERATED_USTRUCT_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MicrosoftOpenXR|OpenXR")
 	FString Keyword;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MicrosoftOpenXR|OpenXR")
 	FInputActionHandlerDynamicSignature Callback;
 };
 


### PR DESCRIPTION
Whitelist MicrosoftOpenXRRuntimeSettings for HoloLens since installed engines were expecting it from the marketplace plugin when packaging for HoloLens.

Add category to public exposed BP properties since engine plugins require that.

Update version to 1.1.2.