### PR TITLE
1.1.3 Update

### DIFF
--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1.2",
+	"VersionName": "1.1.3",
 	"FriendlyName": "Microsoft OpenXR",
 	"Description": "The Microsoft OpenXR plugin is a game plugin which provides additional features available on Microsoft's Mixed Reality devices like the HoloLens 2 when using OpenXR.",
 	"Category": "Augmented Reality",

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/Private/AzureSpatialAnchorsForOpenXR.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/AzureSpatialAnchorsForOpenXR/Private/AzureSpatialAnchorsForOpenXR.cpp
@@ -702,18 +702,10 @@ EAzureSpatialAnchorsResult FAzureSpatialAnchorsForOpenXR::GetActiveWatchers(TArr
 
 	OutWatcherIDs.Reset(Watchers.Size());
 	int32_t Index = 0;
-#if _DEBUG
-	// only lock and test the assert below in debug.
-	auto lock = std::unique_lock<std::mutex>(m_watcherMapMutex);
-#endif
+
 	for (uint32_t i = 0; i < Watchers.Size(); ++i)
 	{
 		OutWatcherIDs.Add(Watchers.GetAt(i).Identifier());
-
-		// All watchers should be in the map.
-#if _DEBUG
-		assert(m_watcherMap.find(ID) != m_watcherMap.end());
-#endif
 	}
 
 	return EAzureSpatialAnchorsResult::Success;

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/LocatableCamPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/LocatableCamPlugin.cpp
@@ -526,7 +526,7 @@ namespace MicrosoftOpenXR
 
 	UARTexture* FLocatableCamPlugin::OnGetARTexture(EARTextureType TextureType) const
 	{ 
-		if (TextureType == EARTextureType::CameraImage)
+		if (SharedTextureHolder && TextureType == EARTextureType::CameraImage)
 		{
 			return SharedTextureHolder->CameraImage;
 		}

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.h
@@ -60,6 +60,7 @@ namespace MicrosoftOpenXR
 
 	struct MeshLocalizationData
 	{
+		winrt::Windows::Foundation::DateTime UpdateTime = winrt::Windows::Foundation::DateTime::min();
 		FTransform LastKnownTransform = FTransform::Identity;
 		EARTrackingState LastKnownTrackingState = EARTrackingState::NotTracking;
 		winrt::Windows::Perception::Spatial::SpatialCoordinateSystem CoordinateSystem;


### PR DESCRIPTION
Camera nullcheck without ARSession
Remove stale _DEBUG code in ASA module
Fix spatial mapping update logic to minimize mesh recreation and fix hitches caused by unnecessary physics baking.