### PR TITLE
Jacksonf/1.1.4

### DIFF
--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1.3",
+	"VersionName": "1.1.4",
 	"FriendlyName": "Microsoft OpenXR",
 	"Description": "The Microsoft OpenXR plugin is a game plugin which provides additional features available on Microsoft's Mixed Reality devices like the HoloLens 2 when using OpenXR.",
 	"Category": "Augmented Reality",

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
@@ -4,7 +4,7 @@
 	"VersionName": "1.1.4",
 	"FriendlyName": "Microsoft OpenXR",
 	"Description": "The Microsoft OpenXR plugin is a game plugin which provides additional features available on Microsoft's Mixed Reality devices like the HoloLens 2 when using OpenXR.",
-	"Category": "Augmented Reality",
+	"Category": "Mixed Reality",
 	"CreatedBy": "Microsoft",
 	"CreatedByURL": "",
 	"DocsURL": "",

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
@@ -254,14 +254,20 @@ namespace MicrosoftOpenXR
 
 	void FHolographicRemotingPlugin::SetRemotingStatusText(FString message, FLinearColor statusColor)
 	{
+		UE_LOG(LogHMD, Log, TEXT("HolographicRemotingPlugin::SetRemotingStatusText: %s"), *message);
+
+		// This function may be called before the world is initialized, which can cause the OpenXRRuntimeSettings to improperly initialize.
+		if (!GWorld)
+		{
+			return;
+		}
+
 #if WITH_EDITOR
 		if (UMicrosoftOpenXRRuntimeSettings::Get() != nullptr)
 		{
 			UMicrosoftOpenXRRuntimeSettings::Get()->OnRemotingStatusChanged.ExecuteIfBound(message, statusColor);
 		}
 #endif
-
-		UE_LOG(LogHMD, Log, TEXT("HolographicRemotingPlugin::SetRemotingStatusText: %s"), *message);
 	}
 
 	void FHolographicRemotingPlugin::UpdateDisconnectedText()

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
@@ -373,7 +373,11 @@ namespace MicrosoftOpenXR
 		// OpenXRHMD will fire a RequestExit when the remoting runtime fails to connect.
 		// 
 		// A Standalone Game PIE should fall back to parsing the command line if remoting is desired.
+#if !UE_VERSION_OLDER_THAN(4, 27, 0)
+		// 4.27 moved GetCustomLoader() later to the RHI initialization, after many engine globals have been initialized.
+		// 4.26 initialization is too early to use IsGame, and will prevent the editor from loading the remoting runtime.
 		if (!FApp::IsGame())
+#endif
 		{
 			ParseRemotingConfig();
 		}

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
@@ -73,6 +73,12 @@ namespace MicrosoftOpenXR
 			break;
 		case XR_TYPE_REMOTING_EVENT_DATA_DISCONNECTED_MSFT:
 			UpdateDisconnectedText();
+			
+			// Workaround for UEVR-2238
+			// When remoting disconnects the OpenXR session is destroyed.
+			// Currently DestroySession does not reset the VRFocus, which prevents input from working when remoting.
+			FApp::SetUseVRFocus(false);
+			FApp::SetHasVRFocus(false);
 			break;
 		}
 	}

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.cpp
@@ -363,7 +363,14 @@ namespace MicrosoftOpenXR
 	bool FHolographicRemotingPlugin::ParseRemotingCmdArgs()
 	{
 #if WITH_EDITOR
-		ParseRemotingConfig();
+		// Only use the remoting settings config from VR PIE. Otherwise, if an AppRemotingPlayer is not running,
+		// OpenXRHMD will fire a RequestExit when the remoting runtime fails to connect.
+		// 
+		// A Standalone Game PIE should fall back to parsing the command line if remoting is desired.
+		if (!FApp::IsGame())
+		{
+			ParseRemotingConfig();
+		}
 #elif !SUPPORTS_REMOTING_IN_PACKAGED_BUILD
 		return false;
 #endif

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.h
@@ -28,6 +28,8 @@
 
 #include "MicrosoftOpenXRRuntimeSettings.h"
 
+#include "Misc/EngineVersionComparison.h"
+
 // Microsoft.Holographic.AppRemoting binaries only exist for Win64.
 #define SUPPORTS_REMOTING_IN_PACKAGED_BUILD (!WITH_EDITOR && PLATFORM_DESKTOP && PLATFORM_64BITS)
 

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/HolographicRemotingPlugin.h
@@ -20,6 +20,8 @@
 #include "OpenXRCore.h"
 #include "HeadMountedDisplayTypes.h"
 
+#include "Engine/World.h"
+
 #if WITH_EDITOR
 #include "Editor.h"
 #endif

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/OpenXRCameraImageTexture.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/OpenXRCameraImageTexture.cpp
@@ -51,17 +51,6 @@ public:
 	{
 		check(IsInRenderingThread());
 
-		FString RHIString = FApp::GetGraphicsRHI();
-		if (RHIString.IsEmpty())
-		{
-			return;
-		}
-
-		if (RHIString != TEXT("DirectX 11"))
-		{
-			return;
-		}
-
 		FSamplerStateInitializerRHI SamplerStateInitializer(SF_Bilinear, AM_Clamp, AM_Clamp, AM_Clamp);
 		SamplerStateRHI = RHICreateSamplerState(SamplerStateInitializer);
 
@@ -267,6 +256,11 @@ UOpenXRCameraImageTexture::UOpenXRCameraImageTexture(const FObjectInitializer& O
 	: Super(ObjectInitializer)
 	, LastUpdateFrame(0)
 {
+	FString RHIString = FApp::GetGraphicsRHI();
+	if (!RHIString.IsEmpty())
+	{
+		IsDX11 = RHIString == TEXT("DirectX 11");
+	}
 }
 
 void UOpenXRCameraImageTexture::BeginDestroy()
@@ -276,6 +270,11 @@ void UOpenXRCameraImageTexture::BeginDestroy()
 
 FTextureResource* UOpenXRCameraImageTexture::CreateResource()
 {
+	if (!IsDX11)
+	{
+		return nullptr;
+	}
+
 #if PLATFORM_WINDOWS || PLATFORM_HOLOLENS
 	return new FOpenXRCameraImageResource(this);
 #else

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/OpenXRCameraImageTexture.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/OpenXRCameraImageTexture.h
@@ -38,5 +38,7 @@ public:
 private:
 	/** Used to prevent two updates of the texture in the same game frame */
 	uint64 LastUpdateFrame;
+
+	bool IsDX11 = false;
 };
 

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.cpp
@@ -166,7 +166,12 @@ namespace MicrosoftOpenXR
 
 	void FQRTrackingPlugin::OnAdded(QRCodeWatcher sender, QRCodeAddedEventArgs args)
 	{
-		auto QRCode = new FOpenXRQRCodeData;
+#if !UE_VERSION_OLDER_THAN(4, 27, 0)
+		auto QRCode = MakeShared<FOpenXRQRCodeData>();
+#else
+		auto QRCode = new FOpenXRQRCodeData();
+#endif
+
 		auto InCode = args.Code();
 
 		QRCode->Id = WMRUtility::GUIDToFGuid(InCode.Id());
@@ -195,7 +200,12 @@ namespace MicrosoftOpenXR
 
 	void FQRTrackingPlugin::OnRemoved(QRCodeWatcher sender, QRCodeRemovedEventArgs args)
 	{
-		auto QRCode = new FOpenXRQRCodeData;
+#if !UE_VERSION_OLDER_THAN(4, 27, 0)
+		auto QRCode = MakeShared<FOpenXRQRCodeData>();
+#else
+		auto QRCode = new FOpenXRQRCodeData();
+#endif
+
 		auto InCode = args.Code();
 
 		QRCode->Id = WMRUtility::GUIDToFGuid(InCode.Id());
@@ -236,7 +246,11 @@ namespace MicrosoftOpenXR
 				}
 			}
 
-			auto OutCode = new FOpenXRQRCodeData;
+#if !UE_VERSION_OLDER_THAN(4, 27, 0)
+			auto OutCode = MakeShared<FOpenXRQRCodeData>();
+#else
+			auto OutCode = new FOpenXRQRCodeData();
+#endif
 
 			OutCode->Id = OutGuid;
 			OutCode->Version = (int32_t)InCode.Version();

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/QRTrackingPlugin.h
@@ -25,6 +25,8 @@
 #include "Windows/HideWindowsPlatformAtomics.h"
 #include "Windows/HideWindowsPlatformTypes.h"
 
+#include "Misc/EngineVersionComparison.h"
+
 class IOpenXRARTrackedGeometryHolder;
 struct FOpenXRQRCodeData;
 

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.cpp
@@ -551,6 +551,11 @@ namespace MicrosoftOpenXR
 
 						FOpenXRMeshUpdate* MeshUpdate = TrackedMeshHolder->AllocateMeshUpdate(MeshId);
 						MeshUpdate->Type = EARObjectClassification::World;
+						// 4.27 adds a new mesh usage flag.
+						// To work with the physics engine, collision must be included.
+#if !UE_VERSION_OLDER_THAN(4, 27, 0)
+						MeshUpdate->SpatialMeshUsageFlags = (EARSpatialMeshUsageFlags)((int32)EARSpatialMeshUsageFlags::Visible | (int32)EARSpatialMeshUsageFlags::Collision);
+#endif
 						CopyMeshData(MeshUpdate, SurfaceMesh);
 
 						if (bIsUpdate)

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.cpp
@@ -255,7 +255,12 @@ namespace MicrosoftOpenXR
 			}
 		}
 
-		auto MeshUpdate = new FOpenXRMeshUpdate;
+#if !UE_VERSION_OLDER_THAN(4, 27, 0)
+		auto MeshUpdate = MakeShared<FOpenXRMeshUpdate>();
+#else
+		auto MeshUpdate = new FOpenXRMeshUpdate();
+#endif
+
 		MeshUpdate->TrackingState = EARTrackingState::Tracking;
 
 		FTransform Transform;

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.h
@@ -87,6 +87,7 @@ namespace MicrosoftOpenXR
 		std::mutex MeshRefsLock;
 		winrt::event_token OnChangeEventToken;
 
+		bool bShouldStartSpatialMapping = false;
 		bool bGenerateSRMeshes = false;
 		float VolumeSize = 20.0f;
 		float TriangleDensity = 500.0f;
@@ -112,6 +113,9 @@ namespace MicrosoftOpenXR
 
 		void OnStartARSession(class UARSessionConfig* SessionConfig) override;
 
+		// Returns true if spatial mapping is desired and ready to start but not yet enabled or started.
+		bool ShouldStartSpatialMapping();
+		bool IsSpatialMappingStartingOrStarted();
 		bool StartMeshObserver();
 		void StopMeshObserver();
 

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.h
@@ -38,6 +38,8 @@
 #include "Windows/HideWindowsPlatformAtomics.h"
 #include "Windows/HideWindowsPlatformTypes.h"
 
+#include "Misc/EngineVersionComparison.h"
+
 namespace MicrosoftOpenXR
 {
 	class WMRAnchorLocalizationData : public TSharedFromThis<WMRAnchorLocalizationData>

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpeechPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpeechPlugin.cpp
@@ -274,7 +274,15 @@ namespace MicrosoftOpenXR
 			{
 				try
 				{
-					SpeechRecognizer.ContinuousRecognitionSession().StopAsync();
+					SpeechRecognizer.ContinuousRecognitionSession().StopAsync().Completed([this](
+						winrt::Windows::Foundation::IAsyncAction action, winrt::Windows::Foundation::AsyncStatus status)
+					{
+						// close the speech recognizer after the recognition session stops.
+						// Otherwise closing the speech recognizer can cause a hang.
+						this->SpeechRecognizer.Constraints().Clear();
+						this->SpeechRecognizer.Close();
+						this->SpeechRecognizer = nullptr;
+					});
 				}
 				catch (winrt::hresult_error e)
 				{
@@ -282,10 +290,12 @@ namespace MicrosoftOpenXR
 					UE_LOG(LogHMD, Warning, TEXT("ContinuousRecognitionSession failed to stop with error: %d"), e.code().value);
 				}
 			}
-
-			SpeechRecognizer.Constraints().Clear();
-			SpeechRecognizer.Close();
-			SpeechRecognizer = nullptr;
+			else
+			{
+				SpeechRecognizer.Constraints().Clear();
+				SpeechRecognizer.Close();
+				SpeechRecognizer = nullptr;
+			}
 		}
 	}
 }	 // namespace MicrosoftOpenXR

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/NuGetModule/packages.config
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/NuGetModule/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.MixedReality.QR" version="0.5.2103" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.7" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.201217.4" targetFramework="native" />
-  <package id="Microsoft.Holographic.Remoting.OpenXr" version="2.5.0" targetFramework="native" />
+  <package id="Microsoft.Holographic.Remoting.OpenXr" version="2.6.0" targetFramework="native" />
   <package id="Microsoft.Azure.SpatialAnchors.WinRT" version="2.7.0" targetFramework="native" />
 </packages>


### PR DESCRIPTION
-  Always start spatial mapping when ToggleARCapture is called on spatial mapping, even if it was called before the ARSession starts
- Update tracked geometry to use a new SharedPtr API in 4.27
- Add spatial mapping visualization/collision type in 4.27
- Wait for speech recognizer to stop before cleaning up to fix a hang when remoting
- Prevent UMicrosoftOpenXRRuntimeSettings initializing too early to workaround remoting UI issue in 4.27
- Update remoting NuGet package to 2.6
- Prevent standalone PIE from terminating when remoting
- Fix input when remoting in 4.27
- Change plugin category to Mixed Reality