### PR TITLE
Fix ASA anchor loading when using XR_MSFT_SPATIAL_ANCHOR_PERSISTENCE

### DIFF
--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1.5",
+	"VersionName": "1.1.6",
 	"FriendlyName": "Microsoft OpenXR",
 	"Description": "The Microsoft OpenXR plugin is a game plugin which provides additional features available on Microsoft's Mixed Reality devices like the HoloLens 2 when using OpenXR.",
 	"Category": "Mixed Reality",


### PR DESCRIPTION
When using the XR_MSFT_SPATIAL_ANCHOR_PERSISTENCE extension, store perception anchors using xrCreateSpatialAnchorFromPerceptionAnchorMSFT

Since the SpatialAnchor plugin is defaulting to the new anchor persistence extension: LoadARPins is only using xrEnumeratePersistedSpatialAnchorNamesMSFT. However, StorePerceptionAnchor was saving to the winrt anchor store which caused ASA anchors to fail to load.

Remove the persisted anchors the ASA plugin creates to prevent the local anchor store from loading unnecessary anchors in future runs.

Update anchor name UTF8 conversion to support extended ascii characters