### PR TITLE
Add GetReferencerName override to FSharedTextureHolder

### DIFF
--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/MicrosoftOpenXR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1.12",
+	"VersionName": "1.1.13",
 	"FriendlyName": "Microsoft OpenXR",
 	"Description": "The Microsoft OpenXR plugin is a game plugin which provides additional features available on Microsoft's Mixed Reality devices like the HoloLens 2 when using OpenXR.",
 	"Category": "Mixed Reality",

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/LocatableCamPlugin.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/LocatableCamPlugin.h
@@ -69,6 +69,11 @@ namespace MicrosoftOpenXR
 		public:
 			virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 
+			virtual FString GetReferencerName() const override
+			{
+				return TEXT("FSharedTextureHolder FGCObject");
+			}
+
 			UOpenXRCameraImageTexture* CameraImage = nullptr;
 		};
 


### PR DESCRIPTION
Add GetReferencerName override to FSharedTextureHolder since it will be pure virtual next release. Currently this will cause a debug break when not overridden.