### PR TITLE
Scene Understanding improvements

### DIFF
--- a/MsftOpenXRGame/Config/DefaultGame.ini
+++ b/MsftOpenXRGame/Config/DefaultGame.ini
@@ -12,8 +12,11 @@ ProjectVersion=1.0.0.0
 HandMeshMaterial=Material'/Game/Materials/M_BasicUnlit.M_BasicUnlit'
 
 [/Script/HoloLensSettings.SceneUnderstanding]
-ShouldDoSceneUnderstandingMeshDetection=true
-SceneUnderstandingVolumeHeight=4
+ShouldDoSceneUnderstandingMeshDetection=false
+ShouldDoSceneUnderstandingHighQualityMeshing=true
+SceneUnderstandingVolumeHeight=0
+SceneUnderstandingVolumeRadius=20
+SceneUnderstandingMeshingLOD=4
 
 [/Script/UnrealEd.ProjectPackagingSettings]
 +DirectoriesToAlwaysStageAsNonUFS=(Path="AzureObjectAnchors")

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SceneUnderstandingBase.h
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SceneUnderstandingBase.h
@@ -121,6 +121,7 @@ namespace MicrosoftOpenXR
 		XrSceneSphereBoundMSFT SceneSphere;
 		float SphereBoundRadius = 10.0f;	// meters
 		float BoundHeight = 0.0f;			// meters
+		XrMeshComputeLodMSFT SpatialMeshingLOD = XR_MESH_COMPUTE_LOD_COARSE_MSFT;
 		bool bShouldStartSceneUnderstanding = false;
 		bool bARSessionStarted = false;
 		bool bCanDetectPlanes = false;

--- a/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.cpp
+++ b/MsftOpenXRGame/Plugins/MicrosoftOpenXR/Source/MicrosoftOpenXR/Private/SpatialMappingPlugin.cpp
@@ -16,7 +16,11 @@ namespace MicrosoftOpenXR
 
 	XrSceneComputeConsistencyMSFT FSpatialMappingPlugin::GetSceneComputeConsistency()
 	{
-		return XR_SCENE_COMPUTE_CONSISTENCY_OCCLUSION_OPTIMIZED_MSFT;
+		bool bShouldDoHighQualityMeshing = false;
+		GConfig->GetBool(TEXT("/Script/HoloLensSettings.SceneUnderstanding"), TEXT("ShouldDoSceneUnderstandingHighQualityMeshing"),
+			bShouldDoHighQualityMeshing, GGameIni);
+
+		return bShouldDoHighQualityMeshing ? XR_SCENE_COMPUTE_CONSISTENCY_SNAPSHOT_INCOMPLETE_FAST_MSFT : XR_SCENE_COMPUTE_CONSISTENCY_OCCLUSION_OPTIMIZED_MSFT;
 	}
 
 	TArray<XrSceneComputeFeatureMSFT> FSpatialMappingPlugin::GetSceneComputeFeatures(class UARSessionConfig* SessionConfig)


### PR DESCRIPTION
This PR adds these features:

1. Spatial Mapping can now use `XR_SCENE_COMPUTE_CONSISTENCY_SNAPSHOT_INCOMPLETE_FAST_MSFT` for mesh data.
This results in a smoother and more complete mesh, trading off speed for quality.

2. Fixes #102

3. Fixes #101 
Support for LOD, defined in https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrMeshComputeLodMSFT.html

4. Changed `SpatialMeshingVolumeSize` from being a platform limited variable to being available anywhere, this is to support Holographic Remoting. Also, renamed it to `SceneUnderstandingVolumeRadius`

5. New config variables to control the features above
`ShouldDoSceneUnderstandingHighQualityMeshing` controls the spatial mapping consistency
`SceneUnderstandingVolumeRadius` renamed and relocated from `SpatialMeshingVolumeSize`
`SceneUnderstandingMeshingLOD` this is a interger based value corresponding to the `XrMeshComputeLodMSFT` definition.

6. Also, there is this issue where the meshes/planes won't be updated the first time because its `UnderlyingMesh` wasn't ready, this PR fixes this by allocating new meshes/planes during `ProcessSceneUpdate` so that its `UnderlyingMesh` will be ready for the mesh/extents data update.